### PR TITLE
Fixed seek on Android

### DIFF
--- a/vg-controls.js
+++ b/vg-controls.js
@@ -486,7 +486,6 @@ angular.module("com.2fdevs.videogular.plugins.controls")
                 var isSeeking = false;
                 var isPlaying = false;
                 var isPlayingWhenSeeking = false;
-                var touchStartX = 0;
                 var LEFT = 37;
                 var RIGHT = 39;
                 var NUM_PERCENT = 5;
@@ -496,19 +495,23 @@ angular.module("com.2fdevs.videogular.plugins.controls")
                     return Math.round(time / 1000);
                 };
 
+                function getOffset(event) {
+                  var el = event.target,
+                    x = 0;
+
+                  while (el && !isNaN(el.offsetLeft)) {
+                    x += el.offsetLeft - el.scrollLeft;
+                    el = el.offsetParent;
+                  }
+
+                  return event.clientX - x;
+                }
+
                 scope.onScrubBarTouchStart = function onScrubBarTouchStart($event) {
                     var event = $event.originalEvent || $event;
                     var touches = event.touches;
-                    var touchX;
 
-                    if (VG_UTILS.isiOSDevice()) {
-                        touchStartX = (touches[0].clientX - event.layerX) * -1;
-                    }
-                    else {
-                        touchStartX = event.layerX;
-                    }
-
-                    touchX = touches[0].clientX + touchStartX - touches[0].target.offsetLeft;
+                    var touchX = getOffset(touches[0]);
 
                     isSeeking = true;
                     if (isPlaying) isPlayingWhenSeeking = true;
@@ -532,10 +535,9 @@ angular.module("com.2fdevs.videogular.plugins.controls")
                 scope.onScrubBarTouchMove = function onScrubBarTouchMove($event) {
                     var event = $event.originalEvent || $event;
                     var touches = event.touches;
-                    var touchX;
+                    var touchX = getOffset(touches[0]);
 
                     if (isSeeking) {
-                        touchX = touches[0].clientX + touchStartX - touches[0].target.offsetLeft;
                         API.seekTime(touchX * API.mediaElement[0].duration / elem[0].scrollWidth);
                     }
 


### PR DESCRIPTION
Seek was broken on Android as this 2fdevs/videogular#287 points out.

It turns out the [UIEvent.layerX](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/layerX) variable was being used to calculate the seek time but it is not part of the standard and it is broken on Android. 
I removed the layerX dependency using [this](http://stackoverflow.com/questions/8389156/what-substitute-should-we-use-for-layerx-layery-since-they-are-deprecated-in-web) piece of advice and now seek works on Android.

I tested this on Android 5.1.1 (Xperia Z3) and iOS 9.0.2 (iPad Mini 2).